### PR TITLE
[리팩토링] AuditingFields의 잘못 표현된 부분 개선

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; //생성일시
+    protected LocalDateTime createdAt; //생성일시
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy; //생성자
+    protected String createdBy; //생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt; //수정일시
+    protected LocalDateTime modifiedAt; //수정일시
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy; //수정자
+    protected String modifiedBy; //수정자
 }


### PR DESCRIPTION
AuditingFields클래스는 추상 클래스이고,
각 필드는 상속 받는 자식 엔티티에서 접근 및 수정이 가능해야 한다.
따라서 접근 제어자를 protected로 했어야 했는데, 이 접근 제어를 초기 설계에서 지나치게 폐쇄적으로 작성했다.
따라서 접근 제어자를 protected로 수정했다.