### PR TITLE
[고도화] Swagger UI로 API 문서화하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.15'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.postgresql:postgresql'


### PR DESCRIPTION
간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행된다.
이 때 Spring Data Rest 가 자동으로 만들어 준 api를
스웨거에 노출시키기 위해 추가 의존성을 사용함

This closes #77 